### PR TITLE
added /proc/net/arp + minor bugfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Rust library to retrieve system, kernel, and process metrics from
 [dependencies]
 env_logger = "0.11.3"
 log = "0.4.21"
+mac_address = { version = "1.1.8", features = ["serde"] }
 regex = "1.10.6"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -29,6 +29,7 @@ Supported Features
 * ✅ `/proc/meminfo`
 
 * ✅ `/proc/net/`
+    * arp
     * dev
     * protocols
     * wireless

--- a/examples/net_arp.rs
+++ b/examples/net_arp.rs
@@ -1,0 +1,14 @@
+use procsys::net_arp;
+
+fn main() {
+    let net_arp_entries = net_arp::collect().expect("network arp entries information");
+
+    // print all network arp entries information in json output
+    match serde_json::to_string_pretty(&net_arp_entries) {
+        Ok(output) => println!("{}", output),
+        Err(err) => {
+            log::error!("{}", err);
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum MetricError {
 
     /// Regex error
     RegexError(regex::Error),
+
+    /// General parse error
+    ParseError(String),
 }
 
 impl fmt::Display for MetricError {
@@ -60,6 +63,7 @@ impl fmt::Display for MetricError {
             MetricError::ProcessNotFound(ref pid) => write!(f, "process (pid={}) not found", pid),
             MetricError::PathNotFound(ref p) => write!(f, "path ({:?}) not found", p),
             MetricError::ByteConvertError(ref unit) => write!(f, "invalid unit: {}", unit),
+            MetricError::ParseError(ref msg) => write!(f, "parse error: {}", msg),
             MetricError::RegexError(ref e) => write!(f, "regex error: {}", e),
             MetricError::InvalidFieldNumberError(ref title, ref num, ref fields) => {
                 write!(f, "invalid {} fields number {}: {:?}", title, num, fields)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod kernel_random;
 pub mod loadavg;
 pub mod meminfo;
+pub mod net_arp;
 pub mod net_dev;
 pub mod net_protocols;
 pub mod net_unix;

--- a/src/net_arp.rs
+++ b/src/net_arp.rs
@@ -1,0 +1,149 @@
+use mac_address;
+use serde::Serialize;
+use std::net;
+
+use crate::{
+    error::{CollectResult, MetricError},
+    utils,
+};
+
+// Learned from https://github.com/prometheus/procfs/arp.go include/uapi/linux/if_arp.h.
+const ATF_COMPLETE: i32 = 0x02;
+const ATF_PERMANENT: i32 = 0x04;
+const ATF_PUBLISH: i32 = 0x08;
+const ATF_USE_TRAILERS: i32 = 0x10;
+const ATF_NETMASK: i32 = 0x20;
+const ATF_DONT_PUBLISH: i32 = 0x40;
+
+/// NetDev contains a network device information parsed from /proc/net/arp
+#[derive(Debug, Serialize, Clone)]
+pub struct ARPEntry {
+    pub ip_address: net::IpAddr,
+    pub hw_address: mac_address::MacAddress,
+    pub device: String,
+    pub flags: i32,
+}
+
+impl ARPEntry {
+    fn new() -> Self {
+        Self {
+            ip_address: net::IpAddr::V4(net::Ipv4Addr::new(0, 0, 0, 0)),
+            hw_address: Default::default(),
+            device: Default::default(),
+            flags: Default::default(),
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.flags == ATF_COMPLETE
+    }
+
+    pub fn is_permanent(&self) -> bool {
+        self.flags == ATF_PERMANENT
+    }
+
+    pub fn is_publish(&self) -> bool {
+        self.flags == ATF_PUBLISH
+    }
+
+    pub fn is_use_trailers(&self) -> bool {
+        self.flags == ATF_USE_TRAILERS
+    }
+
+    pub fn is_netmask(&self) -> bool {
+        self.flags == ATF_NETMASK
+    }
+
+    pub fn is_dont_publish(&self) -> bool {
+        self.flags == ATF_DONT_PUBLISH
+    }
+}
+
+/// collects network device information
+/// # Example
+/// ```
+/// use procsys::net_arp;
+///
+/// let net_arp_entries = net_arp::collect().expect("network arp entries");
+/// let json_output = serde_json::to_string_pretty(&net_arp_entries).unwrap();
+/// println!("{}", json_output);
+///
+/// ```
+pub fn collect() -> CollectResult<Vec<ARPEntry>> {
+    collect_from("/proc/net/arp")
+}
+
+fn collect_from(filename: &str) -> CollectResult<Vec<ARPEntry>> {
+    let mut arp_entries = Vec::new();
+
+    let mut line_index = 0;
+    for line in utils::read_file_lines(filename)? {
+        line_index += 1;
+
+        if line_index == 1 {
+            continue;
+        }
+
+        let fields: Vec<&str> = line.trim().split(' ').filter(|s| !s.is_empty()).collect();
+        let mut arp_entry = ARPEntry::new();
+
+        let ip_addr = match fields[0].parse::<net::IpAddr>() {
+            Ok(ip) => ip,
+            Err(err) => return Err(MetricError::ParseError(err.to_string())),
+        };
+
+        let mac_addr = match fields[3].parse::<mac_address::MacAddress>() {
+            Ok(mac) => mac,
+            Err(err) => return Err(MetricError::ParseError(err.to_string())),
+        };
+
+        let arp_flag = utils::convert_hex_to_i32(fields[2])?;
+
+        arp_entry.ip_address = ip_addr;
+        arp_entry.hw_address = mac_addr;
+        arp_entry.device = fields[5].to_string();
+        arp_entry.flags = arp_flag;
+
+        arp_entries.push(arp_entry);
+    }
+
+    Ok(arp_entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arp_entries() {
+        let arp_entries =
+            collect_from("test_data/fixtures/proc/net/arp").expect("arp entries information");
+        for arp_entry in arp_entries {
+            match arp_entry.hw_address.to_string().as_str() {
+                "00:50:56:C0:00:08" => {
+                    let ip_addr = "192.168.224.1".parse::<net::IpAddr>().expect("ip address");
+                    assert_eq!(arp_entry.ip_address, ip_addr);
+                    assert_eq!(arp_entry.device, "ens33");
+                    assert_eq!(arp_entry.is_complete(), true);
+                    assert_eq!(arp_entry.is_permanent(), false);
+                    assert_eq!(arp_entry.is_publish(), false);
+                    assert_eq!(arp_entry.is_use_trailers(), false);
+                    assert_eq!(arp_entry.is_netmask(), false);
+                    assert_eq!(arp_entry.is_dont_publish(), false);
+                }
+                "00:00:00:00:00:00" => {
+                    let ip_addr = "192.168.224.2".parse::<net::IpAddr>().expect("ip address");
+                    assert_eq!(arp_entry.ip_address, ip_addr);
+                    assert_eq!(arp_entry.device, "ens33");
+                    assert_eq!(arp_entry.is_complete(), false);
+                    assert_eq!(arp_entry.is_permanent(), false);
+                    assert_eq!(arp_entry.is_publish(), false);
+                    assert_eq!(arp_entry.is_use_trailers(), false);
+                    assert_eq!(arp_entry.is_netmask(), false);
+                    assert_eq!(arp_entry.is_dont_publish(), false);
+                }
+                _ => panic!("invalid arp entry hw address: {}", arp_entry.hw_address),
+            }
+        }
+    }
+}

--- a/src/net_wireless.rs
+++ b/src/net_wireless.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde::Serialize;
 
 use crate::{
@@ -65,6 +67,11 @@ fn collect_from(filename: &str) -> CollectResult<Vec<Wireless>> {
     let mut netwireless: Vec<Wireless> = Vec::new();
 
     let mut line_index = 0;
+
+    if !Path::new(filename).exists() {
+        return Ok(netwireless);
+    }
+
     for line in utils::read_file_lines(filename)? {
         line_index += 1;
 

--- a/src/sysfs/class_sas_phy.rs
+++ b/src/sysfs/class_sas_phy.rs
@@ -83,6 +83,11 @@ fn collect_from(dirname: &str) -> CollectResult<HashMap<String, SASPhy>> {
     let mut sas_phys: HashMap<String, SASPhy> = HashMap::new();
     let sas_phy_path = PathBuf::from(dirname);
 
+    let re_port = match Regex::new(r"^port-[0-9:]+$") {
+        Ok(r) => r,
+        Err(err) => return Err(MetricError::RegexError(err)),
+    };
+
     for sas_phy_item in utils::list_dir_content(&sas_phy_path, "", "sas_phy") {
         let mut sas_phy = SASPhy::new();
         let mut sas_phy_item_path = sas_phy_path.clone();
@@ -96,10 +101,6 @@ fn collect_from(dirname: &str) -> CollectResult<HashMap<String, SASPhy>> {
                             .unwrap_or_default();
                 }
                 "device" => {
-                    let re_port = match Regex::new(r"^port-[0-9:]+$") {
-                        Ok(r) => r,
-                        Err(err) => return Err(MetricError::RegexError(err)),
-                    };
                     let mut sas_phy_ports_path = sas_phy_item_path.clone();
                     sas_phy_ports_path.push("device");
                     sas_phy_ports_path.push("port");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -139,3 +139,10 @@ pub fn convert_hex_to_u64(value: &str) -> CollectResult<u64> {
         Err(err) => Err(MetricError::ParseIntError(value.to_string(), err)),
     }
 }
+
+pub fn convert_hex_to_i32(value: &str) -> CollectResult<i32> {
+    match i32::from_str_radix(value.strip_prefix("0x").unwrap_or_default(), 16) {
+        Ok(v) => Ok(v),
+        Err(err) => Err(MetricError::ParseIntError(value.to_string(), err)),
+    }
+}

--- a/test_data/fixtures.ttar
+++ b/test_data/fixtures.ttar
@@ -1082,6 +1082,13 @@ Mode: 644
 Directory: fixtures/proc/net
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: fixtures/proc/net/arp
+Lines: 3
+IP address       HW type     Flags       HW address            Mask     Device
+192.168.224.1    0x1         0x2         00:50:56:c0:00:08     *        ens33
+192.168.224.2    0x1         0x0         00:00:00:00:00:00     *        ens33
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Path: fixtures/proc/net/dev
 Lines: 4
 Inter-|   Receive                                                |  Transmit


### PR DESCRIPTION
- Added /proc/net/arp `procsys::net_arp`
- Bugfix where procsys returns error when /proc/net/arp file does not exist
- Fix code validation issue

## Summary by Sourcery

Introduce a new ARP collector for `/proc/net/arp` and apply minor bug fixes and utility enhancements across the project.

New Features:
- Add `net_arp` module with `ARPEntry` model and `collect` API to parse `/proc/net/arp`
- Include an example application for the ARP collector

Bug Fixes:
- Return an empty list instead of an error when a proc file is missing in the wireless collector

Enhancements:
- Refactor regex compilation in SASPhy collector to remove redundant instantiation inside loops
- Add `convert_hex_to_i32` utility and corresponding `ParseError` variant for improved parsing
- Update error handling messages for parsing failures

Build:
- Add `mac_address` dependency with serde support to Cargo.toml

Documentation:
- Update `FEATURES.md` to list ARP support under `/proc/net/`

Tests:
- Add unit tests for the ARP collector using fixture data